### PR TITLE
Add "subtask" variants of start, stop, and event

### DIFF
--- a/api/src/main/java/io/perfmark/Impl.java
+++ b/api/src/main/java/io/perfmark/Impl.java
@@ -43,13 +43,19 @@ public class Impl {
 
   protected void startTask(String taskName) {}
 
+  protected void startTask(String taskName, String subTaskName) {}
+
   protected void event(String eventName, Tag tag) {}
 
   protected void event(String eventName) {}
 
+  protected void event(String eventName, String subEventName) {}
+
   protected void stopTask(String taskName, Tag tag) {}
 
   protected void stopTask(String taskName) {}
+
+  protected void stopTask(String taskName, String subTaskName) {}
 
   protected Link linkOut() {
     return NO_LINK;

--- a/api/src/main/java/io/perfmark/PerfMark.java
+++ b/api/src/main/java/io/perfmark/PerfMark.java
@@ -95,14 +95,17 @@ public final class PerfMark {
   }
 
   /**
-   * Marks the beginning of a task. If PerfMark is disabled, this method is a no-op. The name of the
-   * task should be a runtime-time constant, usually a string literal. Tasks with the same name can
-   * be grouped together for analysis later, so avoid using too many unique task names.
+   * Marks the beginning of a task. If PerfMark is disabled, this method is a no-op. The names of
+   * the task and subtask should be runtime-time constants, usually a string literal. Tasks with the
+   * same name can be grouped together for analysis later, so avoid using too many unique task
+   * names.
    *
    * @param taskName the name of the task.
+   * @param subTaskName the name of the sub task
+   * @since 0.20.0
    */
   public static void startTask(String taskName, String subTaskName) {
-    impl.startTask(taskName + subTaskName);
+    impl.startTask(taskName, subTaskName);
   }
 
   /**
@@ -130,6 +133,19 @@ public final class PerfMark {
    */
   public static void event(String eventName) {
     impl.event(eventName);
+  }
+
+  /**
+   * Marks an event. Events are logically both a task start and a task end. Events have no duration
+   * associated. Events still represent the instant something occurs. If PerfMark is disabled, this
+   * method is a no-op.
+   *
+   * @param eventName the name of the event.
+   * @param subEventName the name of the sub event.
+   * @since 0.20.0
+   */
+  public static void event(String eventName, String subEventName) {
+    impl.event(eventName, subEventName);
   }
 
   /**
@@ -163,6 +179,24 @@ public final class PerfMark {
    */
   public static void stopTask(String taskName) {
     impl.stopTask(taskName);
+  }
+
+  /**
+   * Marks the end of a task. If PerfMark is disabled, this method is a no-op. The task name should
+   * match the ones provided to the corresponding {@link #startTask(String, String)}. If the task
+   * name or tag do not match, the implementation may not be able to associate the starting and
+   * stopping of a single task. The name of the task should be a runtime-time constant, usually a
+   * string literal.
+   *
+   * <p>It is important that {@link #stopTask} always be called after starting a task, even in case
+   * of exceptions. Failing to do so may result in corrupted results.
+   *
+   * @param taskName the name of the task being ended.
+   * @param subTaskName the name of the sub task being ended.
+   * @since 0.20.0
+   */
+  public static void stopTask(String taskName, String subTaskName) {
+    impl.stopTask(taskName, subTaskName);
   }
 
   /**

--- a/impl/src/main/java/io/perfmark/impl/MarkHolder.java
+++ b/impl/src/main/java/io/perfmark/impl/MarkHolder.java
@@ -26,15 +26,21 @@ public abstract class MarkHolder {
 
   public abstract void start(long gen, String taskName, long nanoTime);
 
+  public abstract void start(long gen, String taskName, String subTaskName, long nanoTime);
+
   public abstract void link(long gen, long linkId);
 
   public abstract void stop(long gen, String taskName, String tagName, long tagId, long nanoTime);
 
   public abstract void stop(long gen, String taskName, long nanoTime);
 
+  public abstract void stop(long gen, String taskName, String subTaskName, long nanoTime);
+
   public abstract void event(long gen, String eventName, String tagName, long tagId, long nanoTime);
 
   public abstract void event(long gen, String eventName, long nanoTime);
+
+  public abstract void event(long gen, String eventName, String subEventName, long nanoTime);
 
   public abstract void attachTag(long gen, String tagName, long tagId);
 

--- a/impl/src/main/java/io/perfmark/impl/NoopMarkHolderProvider.java
+++ b/impl/src/main/java/io/perfmark/impl/NoopMarkHolderProvider.java
@@ -38,6 +38,9 @@ final class NoopMarkHolderProvider extends MarkHolderProvider {
     public void start(long gen, String taskName, long nanoTime) {}
 
     @Override
+    public void start(long gen, String taskName, String subTaskName, long nanoTime) {}
+
+    @Override
     public void link(long gen, long linkId) {}
 
     @Override
@@ -47,10 +50,16 @@ final class NoopMarkHolderProvider extends MarkHolderProvider {
     public void stop(long gen, String taskName, long nanoTime) {}
 
     @Override
+    public void stop(long gen, String taskName, String subTaskName, long nanoTime) {}
+
+    @Override
     public void event(long gen, String eventName, String tagName, long tagId, long nanoTime) {}
 
     @Override
     public void event(long gen, String eventName, long nanoTime) {}
+
+    @Override
+    public void event(long gen, String eventName, String subEventName, long nanoTime) {}
 
     @Override
     public void attachTag(long gen, String tagName, long tagId) {}

--- a/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
+++ b/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
@@ -162,6 +162,15 @@ final class SecretPerfMarkImpl {
     }
 
     @Override
+    protected void startTask(String taskName, String subTaskName) {
+      final long gen = getGen();
+      if (!isEnabled(gen)) {
+        return;
+      }
+      Storage.startAnyways(gen, taskName, subTaskName);
+    }
+
+    @Override
     protected void stopTask(String taskName, Tag tag) {
       final long gen = getGen();
       if (!isEnabled(gen)) {
@@ -180,6 +189,15 @@ final class SecretPerfMarkImpl {
     }
 
     @Override
+    protected void stopTask(String taskName, String subTaskName) {
+      final long gen = getGen();
+      if (!isEnabled(gen)) {
+        return;
+      }
+      Storage.stopAnyways(gen, taskName, subTaskName);
+    }
+
+    @Override
     protected void event(String eventName, Tag tag) {
       final long gen = getGen();
       if (!isEnabled(gen)) {
@@ -195,6 +213,15 @@ final class SecretPerfMarkImpl {
         return;
       }
       Storage.eventAnyways(gen, eventName);
+    }
+
+    @Override
+    protected void event(String eventName, String subEventName) {
+      final long gen = getGen();
+      if (!isEnabled(gen)) {
+        return;
+      }
+      Storage.eventAnyways(gen, eventName, subEventName);
     }
 
     @Override

--- a/impl/src/main/java/io/perfmark/impl/Storage.java
+++ b/impl/src/main/java/io/perfmark/impl/Storage.java
@@ -154,6 +154,10 @@ public final class Storage {
     localMarkHolder.get().start(gen, taskName, System.nanoTime());
   }
 
+  static void startAnyways(long gen, String taskName, String subTaskName) {
+    localMarkHolder.get().start(gen, taskName, subTaskName, System.nanoTime());
+  }
+
   static void stopAnyways(long gen, String taskName, @Nullable String tagName, long tagId) {
     long nanoTime = System.nanoTime();
     localMarkHolder.get().stop(gen, taskName, tagName, tagId, nanoTime);
@@ -164,6 +168,11 @@ public final class Storage {
     localMarkHolder.get().stop(gen, taskName, nanoTime);
   }
 
+  static void stopAnyways(long gen, String taskName, String subTaskName) {
+    long nanoTime = System.nanoTime();
+    localMarkHolder.get().stop(gen, taskName, subTaskName, nanoTime);
+  }
+
   static void eventAnyways(long gen, String eventName, @Nullable String tagName, long tagId) {
     long nanoTime = System.nanoTime();
     localMarkHolder.get().event(gen, eventName, tagName, tagId, nanoTime);
@@ -172,6 +181,11 @@ public final class Storage {
   static void eventAnyways(long gen, String eventName) {
     long nanoTime = System.nanoTime();
     localMarkHolder.get().event(gen, eventName, nanoTime);
+  }
+
+  static void eventAnyways(long gen, String eventName, String subEventName) {
+    long nanoTime = System.nanoTime();
+    localMarkHolder.get().event(gen, eventName, subEventName, nanoTime);
   }
 
   static void linkAnyways(long gen, long linkId) {

--- a/java6/src/jmh/java/io/perfmark/java6/SynchronizedMarkHolderBenchmark.java
+++ b/java6/src/jmh/java/io/perfmark/java6/SynchronizedMarkHolderBenchmark.java
@@ -46,6 +46,13 @@ public class SynchronizedMarkHolderBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void start_name_subname() {
+    markHolder.start(1, "hi", "there", 1234);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void stop_name_tag() {
     markHolder.stop(1, "hi", "tag", 2, 1234);
   }
@@ -55,6 +62,13 @@ public class SynchronizedMarkHolderBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void stop_name_noTag() {
     markHolder.stop(1, "hi", 1234);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void stop_name_subname() {
+    markHolder.stop(1, "hi", "there", 1234);
   }
 
   @Benchmark
@@ -76,5 +90,12 @@ public class SynchronizedMarkHolderBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void event_name_noTag() {
     markHolder.event(1, "hi", 2);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void event_name_subname() {
+    markHolder.event(1, "hi", "there", 2);
   }
 }

--- a/java6/src/test/java/io/perfmark/java6/SynchronizedMarkHolderTest.java
+++ b/java6/src/test/java/io/perfmark/java6/SynchronizedMarkHolderTest.java
@@ -44,6 +44,19 @@ public class SynchronizedMarkHolderTest {
   }
 
   @Test
+  public void taskTagStartStop_subTask() {
+    mh.start(gen, "task", "subtask", 3);
+    mh.stop(gen, "task", "subtask", 4);
+
+    List<Mark> marks = mh.read(false);
+    assertEquals(2, marks.size());
+    List<Mark> expected =
+        Arrays.asList(
+            Mark.taskStart(gen, 3, "task", "subtask"), Mark.taskEnd(gen, 4, "task", "subtask"));
+    assertEquals(expected, marks);
+  }
+
+  @Test
   public void taskTagStartStop_tag() {
     mh.start(gen, "task", "tag", 9, 3);
     mh.stop(gen, "task", "tag", 9, 4);
@@ -115,6 +128,20 @@ public class SynchronizedMarkHolderTest {
     List<Mark> expected =
         Arrays.asList(
             Mark.event(gen, 8, "task1", "tag1", 7), Mark.event(gen, 5, "task2", "tag2", 6));
+    assertEquals(expected, marks);
+  }
+
+  @Test
+  public void event_subevent() {
+    mh.event(gen, "task1", "subtask3", 8);
+    mh.event(gen, "task2", "subtask4", 5);
+
+    List<Mark> marks = mh.read(false);
+
+    assertEquals(2, marks.size());
+    List<Mark> expected =
+        Arrays.asList(
+            Mark.event(gen, 8, "task1", "subtask3"), Mark.event(gen, 5, "task2", "subtask4"));
     assertEquals(expected, marks);
   }
 

--- a/java9/src/jmh/java/io/perfmark/java9/VarHandleMarkHolderBenchmark.java
+++ b/java9/src/jmh/java/io/perfmark/java9/VarHandleMarkHolderBenchmark.java
@@ -46,6 +46,13 @@ public class VarHandleMarkHolderBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void start_name_subname() {
+    markHolder.start(1, "hi", "there", 1234);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void stop_name_tag() {
     markHolder.stop(1, "hi", "tag", 2, 1234);
   }
@@ -55,6 +62,13 @@ public class VarHandleMarkHolderBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void stop_name_noTag() {
     markHolder.stop(1, "hi", 1234);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void stop_name_subname() {
+    markHolder.stop(1, "hi", "there", 1234);
   }
 
   @Benchmark
@@ -76,5 +90,12 @@ public class VarHandleMarkHolderBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void event_name_noTag() {
     markHolder.event(1, "hi", 8);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void event_name_subname() {
+    markHolder.event(1, "hi", "there", 2);
   }
 }

--- a/java9/src/test/java/io/perfmark/java9/VarHandleMarkHolderTest.java
+++ b/java9/src/test/java/io/perfmark/java9/VarHandleMarkHolderTest.java
@@ -51,6 +51,19 @@ public class VarHandleMarkHolderTest {
   }
 
   @Test
+  public void taskTagStartStop_subTask() {
+    mh.start(gen, "task", "subtask", 3);
+    mh.stop(gen, "task", "subtask", 4);
+
+    List<Mark> marks = mh.read(false);
+    assertEquals(2, marks.size());
+    List<Mark> expected =
+        Arrays.asList(
+            Mark.taskStart(gen, 3, "task", "subtask"), Mark.taskEnd(gen, 4, "task", "subtask"));
+    assertEquals(expected, marks);
+  }
+
+  @Test
   public void taskTagStartStop_tag() {
     mh.start(gen, "task", "tag", 9, 3);
     mh.stop(gen, "task", "tag", 9, 4);
@@ -122,6 +135,20 @@ public class VarHandleMarkHolderTest {
     List<Mark> expected =
         Arrays.asList(
             Mark.event(gen, 8, "task1", "tag1", 7), Mark.event(gen, 5, "task2", "tag2", 6));
+    assertEquals(expected, marks);
+  }
+
+  @Test
+  public void event_subevent() {
+    mh.event(gen, "task1", "subtask3", 8);
+    mh.event(gen, "task2", "subtask4", 5);
+
+    List<Mark> marks = mh.read(false);
+
+    assertEquals(2, marks.size());
+    List<Mark> expected =
+        Arrays.asList(
+            Mark.event(gen, 8, "task1", "subtask3"), Mark.event(gen, 5, "task2", "subtask4"));
     assertEquals(expected, marks);
   }
 


### PR DESCRIPTION
Sub tasks are meant for use when the task name is a concatenation of two, runtime constant
strings, but the caller doesn't want to pay the allocation cost.  None of these methods
support Tag overloads, and instead expect callers to invoke attachTag instead.

Perf:

```
Benchmark                                                  Mode  Cnt   Score   Error  Units
VarHandleGeneratorBenchmark.getAndSetAndGetGeneration      avgt    5   2.610 ± 0.022  ns/op
VarHandleGeneratorBenchmark.getGeneration                  avgt    5   2.379 ± 0.330  ns/op
VarHandleGeneratorBenchmark.racyGetAndSetAndGetGeneration  avgt    5  21.905 ± 2.327  ns/op
VarHandleMarkHolderBenchmark.event_name_noTag              avgt    5   3.581 ± 0.178  ns/op
VarHandleMarkHolderBenchmark.event_name_subname            avgt    5   4.131 ± 0.058  ns/op
VarHandleMarkHolderBenchmark.event_name_tag                avgt    5   4.417 ± 0.083  ns/op
VarHandleMarkHolderBenchmark.link                          avgt    5   2.301 ± 0.038  ns/op
VarHandleMarkHolderBenchmark.start_name_noTag              avgt    5   3.460 ± 0.048  ns/op
VarHandleMarkHolderBenchmark.start_name_subname            avgt    5   3.987 ± 0.090  ns/op
VarHandleMarkHolderBenchmark.start_name_tag                avgt    5   4.448 ± 0.082  ns/op
VarHandleMarkHolderBenchmark.stop_name_noTag               avgt    5   3.505 ± 0.042  ns/op
VarHandleMarkHolderBenchmark.stop_name_subname             avgt    5   4.019 ± 0.056  ns/op
VarHandleMarkHolderBenchmark.stop_name_tag                 avgt    5   4.503 ± 0.054  ns/op

Benchmark                                                 Mode  Cnt   Score   Error  Units
SynchronizedMarkHolderBenchmark.event_name_noTag          avgt    5   5.910 ± 0.077  ns/op
SynchronizedMarkHolderBenchmark.event_name_subname        avgt    5   7.843 ± 0.064  ns/op
SynchronizedMarkHolderBenchmark.event_name_tag            avgt    5   9.060 ± 0.116  ns/op
SynchronizedMarkHolderBenchmark.link                      avgt    5   3.474 ± 0.051  ns/op
SynchronizedMarkHolderBenchmark.start_name_noTag          avgt    5   5.849 ± 0.067  ns/op
SynchronizedMarkHolderBenchmark.start_name_subname        avgt    5   7.791 ± 0.093  ns/op
SynchronizedMarkHolderBenchmark.start_name_tag            avgt    5   9.105 ± 0.176  ns/op
SynchronizedMarkHolderBenchmark.stop_name_noTag           avgt    5   6.595 ± 0.109  ns/op
SynchronizedMarkHolderBenchmark.stop_name_subname         avgt    5   7.993 ± 0.071  ns/op
SynchronizedMarkHolderBenchmark.stop_name_tag             avgt    5   9.195 ± 0.082  ns/op
VolatileGeneratorBenchmark.getAndSetAndGetGeneration      avgt    5   7.712 ± 0.121  ns/op
VolatileGeneratorBenchmark.getGeneration                  avgt    5   2.262 ± 0.012  ns/op
VolatileGeneratorBenchmark.ifEnabled                      avgt    5   0.692 ± 0.007  ns/op
VolatileGeneratorBenchmark.racyGetAndSetAndGetGeneration  avgt    5  93.333 ± 2.295  ns/op
```