### PR TITLE
Upgrade errorprone dependency to 2.3.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
     artifacts = [
         "junit:junit:4.12",
-        "com.google.errorprone:error_prone_annotations:2.3.3",
+        "com.google.errorprone:error_prone_annotations:2.3.4",
         "com.google.code.findbugs:jsr305:3.0.2",
         "com.google.code.gson:gson:2.8.5",
         "com.google.truth:truth:0.46",

--- a/agent/src/main/java/io/perfmark/agent/PerfMarkTransformer.java
+++ b/agent/src/main/java/io/perfmark/agent/PerfMarkTransformer.java
@@ -257,7 +257,7 @@ final class PerfMarkTransformer implements ClassFileTransformer {
     @Override
     public MethodVisitor visitMethod(
         int access, String name, String descriptor, String signature, String[] exceptions) {
-      return new PerfMarkTransformer.PerfMarkMethodRewriter.PerfMarkMethodVisitor(
+      return new PerfMarkMethodRewriter.PerfMarkMethodVisitor(
           perfmarkClassReader.api(),
           super.visitMethod(access, name, descriptor, signature, exceptions),
           name);

--- a/agent/src/main/java/io/perfmark/agent/PerfMarkTransformer.java
+++ b/agent/src/main/java/io/perfmark/agent/PerfMarkTransformer.java
@@ -151,7 +151,7 @@ final class PerfMarkTransformer implements ClassFileTransformer {
     public MethodVisitor visitMethod(
         int access, String name, String descriptor, String signature, String[] exceptions) {
       clinitSeen = clinitSeen || name.equals("<clinit>");
-      return new PerfMarkMethodVisitor(
+      return new PerfMarkClassReader.PerfMarkMethodVisitor(
           super.visitMethod(access, name, descriptor, signature, exceptions), name);
     }
 
@@ -257,7 +257,7 @@ final class PerfMarkTransformer implements ClassFileTransformer {
     @Override
     public MethodVisitor visitMethod(
         int access, String name, String descriptor, String signature, String[] exceptions) {
-      return new PerfMarkMethodVisitor(
+      return new PerfMarkTransformer.PerfMarkMethodRewriter.PerfMarkMethodVisitor(
           perfmarkClassReader.api(),
           super.visitMethod(access, name, descriptor, signature, exceptions),
           name);

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ subprojects {
 
     if (rootProject.properties.get('errorProne', true)) {
         dependencies {
-            errorprone 'com.google.errorprone:error_prone_core:2.3.3'
+            errorprone 'com.google.errorprone:error_prone_core:2.3.4'
             errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
         }
     } else {
@@ -144,7 +144,7 @@ subprojects {
 
     ext {
         libraries = [
-                errorprone: 'com.google.errorprone:error_prone_annotations:2.3.3',
+                errorprone: 'com.google.errorprone:error_prone_annotations:2.3.4',
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
                 gson: 'com.google.code.gson:gson:2.8.6',
                 truth: 'com.google.truth:truth:1.0'


### PR DESCRIPTION
Upgrade errorprone dependency to 2.3.4.

# Background
grpc-java complained perfmark's errorprone annotation 2.3.3: https://github.com/grpc/grpc-java/pull/6574/files#r361732377 .

```
    compile (libraries.perfmark) {
        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
    }
```

If a perfmark release has newer version, grpc-java does not need to have the exclusion clause.