### PR TITLE
Fix ErrorProne warnings

### DIFF
--- a/java9/build.gradle
+++ b/java9/build.gradle
@@ -56,3 +56,7 @@ jcstress {
     // mode "tough"
     deoptRatio "2"
 }
+
+compileJcstressJava {
+    options.errorprone.excludedPaths = ".*/build/generated/sources/annotationProcessor/.*"
+}

--- a/java9/src/test/java/io/perfmark/java9/VarHandleMarkHolderTest.java
+++ b/java9/src/test/java/io/perfmark/java9/VarHandleMarkHolderTest.java
@@ -22,7 +22,6 @@ import io.perfmark.impl.Generator;
 import io.perfmark.impl.Mark;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -198,7 +197,6 @@ public class VarHandleMarkHolderTest {
 
   @Test
   public void read_getsAllButLastIfNotWriter() {
-    Assume.assumeTrue("holder " + mh + " is not fixed size", mh instanceof VarHandleMarkHolder);
     int events = mh.maxMarks() - 1;
     for (int i = 0; i < events; i++) {
       mh.start(gen, "task", 3);
@@ -210,7 +208,6 @@ public class VarHandleMarkHolderTest {
 
   @Test
   public void read_getsAllIfNotWriterButNoWrap() {
-    Assume.assumeTrue("holder " + mh + " is not fixed size", mh instanceof VarHandleMarkHolder);
     int events = mh.maxMarks() - 2;
     for (int i = 0; i < events; i++) {
       mh.start(gen, "task", 3);


### PR DESCRIPTION
We don't care about ErrorProne issues with jcstress's generated code.
VarHandleMarkHolderTest's warnings seem caused by checks that became obsolete
in f59adcfa.

Sampling of the fixed failures:
```
perfmark/java9/build/generated/sources/annotationProcessor/java/jcstress/org/openjdk/jcstress/infra/results/L_Result_jcstress.java:24: warning: [HidingField] Hiding fields of superclasses may cause confusion and errors. This field is hiding a field of the same name in superclass: L_Result_jcstress_c2
    boolean p000, p001, p002, p003, p004, p005, p006, p007, p008, p009, p010, p011, p012, p013, p014, p015;
            ^
    (see https://errorprone.info/bugpattern/HidingField)
perfmark/java9/src/test/java/io/perfmark/java9/VarHandleMarkHolderTest.java:201: warning: [ObjectToString] VarHandleMarkHolder is final and does not override Object.toString, so converting it to a string will print its identity (e.g. `VarHandleMarkHolder@ 4488aabb`) instead of useful information.
    Assume.assumeTrue("holder " + mh + " is not fixed size", mh instanceof VarHandleMarkHolder);
                                  ^
    (see https://errorprone.info/bugpattern/ObjectToString)
perfmark/java9/src/test/java/io/perfmark/java9/VarHandleMarkHolderTest.java:201: warning: [BadInstanceof] `mh` is an instance of VarHandleMarkHolder which is a subtype of VarHandleMarkHolder, so this is equivalent to a null check.
    Assume.assumeTrue("holder " + mh + " is not fixed size", mh instanceof VarHandleMarkHolder);
                                                                ^
    (see https://errorprone.info/bugpattern/BadInstanceof)
  Did you mean 'Assume.assumeTrue("holder " + mh + " is not fixed size", mh != null);'?
```