### PR TITLE
Add perfmark-traceviewer to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ tracing function calls to their code to see how long each part takes.
 To use PerfMark, add the following dependencies to your `build.gradle`:
 - `io.perfmark:perfmark-api:0.20.1`
 - `io.perfmark:perfmark-traceviewer:0.20.1`
+
 In your code, add the PerfMark tracing calls like so:
 
 ```java

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ tracing function calls to their code to see how long each part takes.
 
 To use PerfMark, add the following dependencies to your `build.gradle`:
 - `io.perfmark:perfmark-api:0.20.1`
-- `io.perfmark:perfmark-traceviewer:0.20.1` - view trace in browser.
+- `io.perfmark:perfmark-traceviewer:0.20.1`
 In your code, add the PerfMark tracing calls like so:
 
 ```java

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ tracing function calls to their code to see how long each part takes.
     
 ## Usage
 
-To use PerfMark, add a dependency on `io.perfmark:perfmark-api:0.20.1`.  In your code, add the 
-PerfMark tracing calls like so:
+To use PerfMark, add the following dependencies to your `build.gradle`:
+- `io.perfmark:perfmark-api:0.20.1`
+- `io.perfmark:perfmark-traceviewer:0.20.1` - view trace in browser.
+In your code, add the PerfMark tracing calls like so:
 
 ```java
 Map<String, Header> parseHeaders(List<String> rawHeaders) {


### PR DESCRIPTION
When I tried to use PerfMark and generate the html traces, I didn't have the proper trace library added. This just adds it to the README.