### PR TITLE
api,impl: add a delayed tag impl

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,8 +20,8 @@ dependencies {
 }
 
 compileTestJava {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 compileJmhJava {

--- a/api/src/main/java/io/perfmark/Impl.java
+++ b/api/src/main/java/io/perfmark/Impl.java
@@ -71,6 +71,9 @@ public class Impl {
 
   protected void attachTag(String tagName, long tagValue0, long tagValue1) {}
 
+  protected <T> void attachTag(
+      String tagName, T tagObject, StringFunction<? super T> stringFunction) {}
+
   protected Tag createTag(@Nullable String tagName, long tagId) {
     return NO_TAG;
   }

--- a/api/src/main/java/io/perfmark/StringFunction.java
+++ b/api/src/main/java/io/perfmark/StringFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.perfmark;
+
+/**
+ * This interface is equivalent to {@code java.util.function.Function}. It is here as a
+ * compatibility shim to make PerfMark compatible with Java 6. This will likely be removed if
+ * PerfMark picks Java 8 as the minimum support version. See {@link PerfMark} for expected usage.
+ *
+ * @since 0.22.0
+ * @param <T> The type to turn into a String.
+ */
+public interface StringFunction<T> {
+
+  /**
+   * Takes the given argument and produces a String.
+   *
+   * @since 0.22.0
+   * @param t the subject to Stringify
+   * @return the String
+   */
+  String apply(T t);
+}


### PR DESCRIPTION
This allows delaying a tag being attached until later, in case the tag processing is expensive.    I only added it for tags, but a similar pattern can be used for events and tasks.   I gave myself some leeway with the implementation, but decided to be conservative with this PR.   Rather than stringifying the args on /reading/, it stringifies them on write.  I can't think of a clear way of expressing this distinction in the method name; ideas are welcome.  Stringing at write incurs a possible waste of work, but avoids synchronization and memory retention issues.   Stringing at read reduces the overhead of adding tags.
