### PR TITLE
api: add benchmarks for Lambda based tags

### DIFF
--- a/api/src/jmh/java/io/perfmark/EnabledBenchmark.java
+++ b/api/src/jmh/java/io/perfmark/EnabledBenchmark.java
@@ -33,6 +33,8 @@ public class EnabledBenchmark {
   @Param({"true", "false"})
   public boolean enabled;
 
+  final String there = "there";
+
   @Setup
   public void setup() {
     PerfMark.setEnabled(enabled);
@@ -87,5 +89,38 @@ public class EnabledBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void attachKeyedTag_snn() {
     PerfMark.attachTag("hi", 934, 5);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void attachKeyedTag_ss_methodRef() {
+    PerfMark.attachTag("hi", this, EnabledBenchmark::getStringValue);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void attachKeyedTag_ss_ctor() {
+    PerfMark.attachTag("hi", there, String::new);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void attachKeyedTag_ss_globalRef() {
+    PerfMark.attachTag("hi", this, ignore -> this.there);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void attachKeyedTag_ss_localRef() {
+    String bar = there;
+    PerfMark.attachTag("hi", this, ignore -> bar);
+  }
+
+  static String getStringValue(EnabledBenchmark self) {
+    return self.there;
   }
 }


### PR DESCRIPTION
```
Benchmark                                     (enabled)  Mode  Cnt   Score   Error  Units
EnabledBenchmark.attachKeyedTag_sn                 true  avgt    5   7.275 ± 0.269  ns/op
EnabledBenchmark.attachKeyedTag_sn                false  avgt    5   0.605 ± 0.006  ns/op
EnabledBenchmark.attachKeyedTag_snn                true  avgt    5   8.585 ± 0.309  ns/op
EnabledBenchmark.attachKeyedTag_snn               false  avgt    5   0.631 ± 0.052  ns/op
EnabledBenchmark.attachKeyedTag_ss                 true  avgt    5   8.521 ± 0.315  ns/op
EnabledBenchmark.attachKeyedTag_ss                false  avgt    5   0.617 ± 0.009  ns/op
EnabledBenchmark.attachKeyedTag_ss_ctor            true  avgt    5  21.671 ± 0.276  ns/op
EnabledBenchmark.attachKeyedTag_ss_ctor           false  avgt    5   0.621 ± 0.003  ns/op
EnabledBenchmark.attachKeyedTag_ss_globalRef       true  avgt    5   7.739 ± 0.216  ns/op
EnabledBenchmark.attachKeyedTag_ss_globalRef      false  avgt    5   0.627 ± 0.004  ns/op
EnabledBenchmark.attachKeyedTag_ss_localRef        true  avgt    5   7.558 ± 0.207  ns/op
EnabledBenchmark.attachKeyedTag_ss_localRef       false  avgt    5   0.606 ± 0.008  ns/op
EnabledBenchmark.attachKeyedTag_ss_methodRef       true  avgt    5   8.483 ± 0.109  ns/op
EnabledBenchmark.attachKeyedTag_ss_methodRef      false  avgt    5   0.627 ± 0.004  ns/op
EnabledBenchmark.createTag                         true  avgt    5   5.306 ± 0.347  ns/op
EnabledBenchmark.createTag                        false  avgt    5   2.741 ± 0.015  ns/op
EnabledBenchmark.event                             true  avgt    5  32.873 ± 0.450  ns/op
EnabledBenchmark.event                            false  avgt    5   0.607 ± 0.005  ns/op
EnabledBenchmark.link                              true  avgt    5  12.043 ± 1.489  ns/op
EnabledBenchmark.link                             false  avgt    5   0.607 ± 0.005  ns/op
EnabledBenchmark.startStop                         true  avgt    5  62.132 ± 0.310  ns/op
EnabledBenchmark.startStop                        false  avgt    5   0.610 ± 0.003  ns/op
```