### PR TITLE
all: add a method to start tasks with a string function

### DIFF
--- a/api/src/jmh/java/io/perfmark/EnabledBenchmark.java
+++ b/api/src/jmh/java/io/perfmark/EnabledBenchmark.java
@@ -51,6 +51,14 @@ public class EnabledBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void startStop_method() {
+    PerfMark.startTask("hi", String::valueOf);
+    PerfMark.stopTask();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public Tag createTag() {
     return PerfMark.createTag("tag", 2);
   }

--- a/api/src/main/java/io/perfmark/Impl.java
+++ b/api/src/main/java/io/perfmark/Impl.java
@@ -39,6 +39,8 @@ public class Impl {
 
   protected void setEnabled(boolean value) {}
 
+  protected <T> void startTask(T taskNameObject, StringFunction<? super T> taskNameFunc) {}
+
   protected void startTask(String taskName, Tag tag) {}
 
   protected void startTask(String taskName) {}

--- a/api/src/main/java/io/perfmark/PerfMark.java
+++ b/api/src/main/java/io/perfmark/PerfMark.java
@@ -95,6 +95,18 @@ public final class PerfMark {
   }
 
   /**
+   * Marks the beginning of a task. If PerfMark is disabled, this method is a no-op. The name of the
+   * task should be a runtime-time constant, usually a string literal. Tasks with the same name can
+   * be grouped together for analysis later, so avoid using too many unique task names.
+   *
+   * @param taskNameObject the name of the task.
+   * @param taskNameFunction the function that will convert the taskNameObject to a String
+   */
+  public static <T> void startTask(T taskNameObject, StringFunction<? super T> taskNameFunction) {
+    impl.startTask(taskNameObject, taskNameFunction);
+  }
+
+  /**
    * Marks the beginning of a task. If PerfMark is disabled, this method is a no-op. The names of
    * the task and subtask should be runtime-time constants, usually a string literal. Tasks with the
    * same name can be grouped together for analysis later, so avoid using too many unique task

--- a/api/src/main/java/io/perfmark/PerfMark.java
+++ b/api/src/main/java/io/perfmark/PerfMark.java
@@ -99,8 +99,12 @@ public final class PerfMark {
    * task should be a runtime-time constant, usually a string literal. Tasks with the same name can
    * be grouped together for analysis later, so avoid using too many unique task names.
    *
+   * <p>This function has many more caveats than the {@link #startTask(String)} that accept a
+   * string. See the docs at {@link #attachTag(String, Object, StringFunction)} for a list of risks
+   * associated with passing a function.
+   *
    * @param taskNameObject the name of the task.
-   * @param taskNameFunction the function that will convert the taskNameObject to a String
+   * @param taskNameFunction the function that will convert the taskNameObject to a taskName
    */
   public static <T> void startTask(T taskNameObject, StringFunction<? super T> taskNameFunction) {
     impl.startTask(taskNameObject, taskNameFunction);

--- a/api/src/test/java/io/perfmark/PerfMarkTest.java
+++ b/api/src/test/java/io/perfmark/PerfMarkTest.java
@@ -91,7 +91,7 @@ public class PerfMarkTest {
     PerfMark.startTask("task2", tag2);
     PerfMark.startTask("task3", tag3);
     PerfMark.startTask("task4");
-    PerfMark.startTask("task5");
+    PerfMark.startTask("task5", String::valueOf);
     PerfMark.attachTag(PerfMark.createTag("extra"));
     PerfMark.attachTag("name", "extra2", String::valueOf);
     Link link = PerfMark.linkOut();
@@ -138,7 +138,7 @@ public class PerfMarkTest {
     PerfMark.attachTag("name", "extra2", null);
 
     List<Mark> marks = Storage.readForTest();
-    Truth.assertThat(marks).hasSize(0);
+    Truth.assertThat(marks).hasSize(1);
   }
 
   @Test
@@ -154,7 +154,7 @@ public class PerfMarkTest {
         });
 
     List<Mark> marks = Storage.readForTest();
-    Truth.assertThat(marks).hasSize(0);
+    Truth.assertThat(marks).hasSize(1);
   }
 
   @Test
@@ -177,7 +177,7 @@ public class PerfMarkTest {
         });
 
     List<Mark> marks = Storage.readForTest();
-    Truth.assertThat(marks).hasSize(0);
+    Truth.assertThat(marks).hasSize(1);
   }
 
   @Test
@@ -198,7 +198,7 @@ public class PerfMarkTest {
         });
 
     List<Mark> marks = Storage.readForTest();
-    Truth.assertThat(marks).hasSize(0);
+    Truth.assertThat(marks).hasSize(1);
   }
 
   public static final class FakeGenerator extends Generator {

--- a/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
+++ b/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
@@ -34,9 +34,6 @@ final class SecretPerfMarkImpl {
     private static final Tag NO_TAG = packTag(Mark.NO_TAG_NAME, Mark.NO_TAG_ID);
     private static final Link NO_LINK = packLink(Mark.NO_LINK_ID);
     private static final long INCREMENT = 1L << Generator.GEN_OFFSET;
-    /** Sigyl value used for identity comparison. */
-    @SuppressWarnings("StringOperationCanBeSimplified")
-    private static final String NO_TAG_VALUE = new String("");
 
     private static final String START_ENABLED_PROPERTY = "io.perfmark.PerfMark.startEnabled";
 
@@ -176,6 +173,16 @@ final class SecretPerfMarkImpl {
     }
 
     @Override
+    protected <T> void startTask(T taskNameObject, StringFunction<? super T> stringFunction) {
+      final long gen = getGen();
+      if (!isEnabled(gen)) {
+        return;
+      }
+      String taskName = deriveTaskValue(taskNameObject, stringFunction);
+      Storage.startAnyways(gen, taskName);
+    }
+
+    @Override
     protected void stopTask() {
       final long gen = getGen();
       if (!isEnabled(gen)) {
@@ -257,7 +264,6 @@ final class SecretPerfMarkImpl {
     }
 
     @Override
-    @SuppressWarnings({"StringEquality", "ReferenceEquality"})
     protected <T> void attachTag(
         String tagName, T tagObject, StringFunction<? super T> stringFunction) {
       final long gen = getGen();
@@ -265,23 +271,25 @@ final class SecretPerfMarkImpl {
         return;
       }
       String tagValue = deriveTagValue(tagName, tagObject, stringFunction);
-      if (tagValue != NO_TAG_VALUE) {
-        Storage.attachKeyedTagAnyways(gen, tagName, tagValue);
-      }
+      Storage.attachKeyedTagAnyways(gen, tagName, tagValue);
     }
 
     static <T> String deriveTagValue(
         String tagName, T tagObject, StringFunction<? super T> stringFunction) {
-      if (stringFunction == null) {
-        handleTagValueFailure(
-            tagName, tagObject, stringFunction, new NullPointerException("stringFunction"));
-        return NO_TAG_VALUE;
-      }
       try {
         return stringFunction.apply(tagObject);
       } catch (Throwable t) {
         handleTagValueFailure(tagName, tagObject, stringFunction, t);
-        return NO_TAG_VALUE;
+        return "PerfMarkTagError:" + t.getClass().getName();
+      }
+    }
+
+    static <T> String deriveTaskValue(T taskNameObject, StringFunction<? super T> stringFunction) {
+      try {
+        return stringFunction.apply(taskNameObject);
+      } catch (Throwable t) {
+        handleTaskNameFailure(taskNameObject, stringFunction, t);
+        return "PerfMarkTaskError:" + t.getClass().getName();
       }
     }
 
@@ -305,6 +313,25 @@ final class SecretPerfMarkImpl {
             Level.WARNING,
             "PerfMark.attachTag failed for {0}: {1}",
             new Object[] {tagName, t.getClass()});
+      }
+    }
+
+    static <T> void handleTaskNameFailure(
+        T taskNameObject, StringFunction<? super T> stringFunction, Throwable cause) {
+      try {
+        if (logger.isLoggable(Level.WARNING)) {
+          LogRecord lr =
+              new LogRecord(
+                  Level.WARNING, "PerfMark.startTask ignored: taskObject={0}, stringFunction={1}");
+          lr.setParameters(new Object[] {taskNameObject, stringFunction});
+          lr.setThrown(cause);
+          logger.log(lr);
+        }
+      } catch (Throwable t) {
+        // Need to be careful here.  It's possible that the Exception thrown may itself throw
+        // while trying to convert it to a String.  Instead, only pass the class name, which is
+        // safer than passing the whole object.
+        logger.log(Level.WARNING, "PerfMark.startTask failed for {0}", new Object[] {t.getClass()});
       }
     }
 


### PR DESCRIPTION
I decided to make string function failures still record, because otherwise it may cause task imbalances.  