### PR TITLE
all: Add automatic module support

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -1,4 +1,5 @@
 description = "PerfMark Agent"
+ext.moduleName = "io.perfmark.agent"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,4 +1,5 @@
 description = "PerfMark API"
+ext.moduleName = "io.perfmark"
 
 if (JavaVersion.current().isJava12Compatible()) {
     sourceCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,9 @@ subprojects {
         }
     }
 
-    jar {
-        afterEvaluate {
+    afterEvaluate {
+
+        jar {
             if (sourceCompatibility < JavaVersion.VERSION_1_9) {
                 manifest {
                     attributes  'Automatic-Module-Name': moduleName
@@ -59,6 +60,7 @@ subprojects {
             }
         }
     }
+
 
     publishing {
         publications {

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ subprojects {
     }
 
     afterEvaluate {
-
         jar {
             if (sourceCompatibility < JavaVersion.VERSION_1_9) {
                 manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.github.erizo.gradle:jcstress-gradle-plugin:0.8.3'
+        classpath 'com.github.erizo.gradle:jcstress-gradle-plugin:0.8.8'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.1'
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.5.3"
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8"

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.1'
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.5.3"
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8"
+        classpath "org.javamodularity:moduleplugin:1.7.0"
     }
 }
 
@@ -49,7 +50,15 @@ subprojects {
         }
     }
 
-
+    jar {
+        afterEvaluate {
+            if (sourceCompatibility < JavaVersion.VERSION_1_9) {
+                manifest {
+                    attributes  'Automatic-Module-Name': moduleName
+                }
+            }
+        }
+    }
 
     publishing {
         publications {
@@ -116,6 +125,10 @@ subprojects {
 
     [publishMavenPublicationToMavenRepository, publishMavenPublicationToMavenLocal]*.onlyIf {
         !name.contains("perfmark-agent")
+    }
+
+    [javadoc]*.onlyIf {
+        !name.contains("perfmark-java9")
     }
 
 

--- a/impl/build.gradle
+++ b/impl/build.gradle
@@ -1,4 +1,5 @@
 description = "PerfMark Implementation API"
+ext.moduleName =  "io.perfmark.impl"
 
 if (JavaVersion.current().isJava12Compatible()) {
     sourceCompatibility = 1.7

--- a/java6/build.gradle
+++ b/java6/build.gradle
@@ -1,4 +1,5 @@
 description = "PerfMark Java6 API"
+ext.moduleName = "io.perfmark.java6"
 
 if (JavaVersion.current().isJava12Compatible()) {
     sourceCompatibility = 1.7

--- a/java7/build.gradle
+++ b/java7/build.gradle
@@ -1,4 +1,5 @@
 description = "PerfMark Java7 API"
+ext.moduleName = "io.perfmark.java7"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/java9/build.gradle
+++ b/java9/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'jcstress'
+apply plugin: "org.javamodularity.moduleplugin"
 
 description = "PerfMark Java9 API"
+ext.moduleName = "io.perfmark.java9"
 
 if (!JavaVersion.current().isJava9Compatible()) {
     project.tasks.all {

--- a/java9/build.gradle
+++ b/java9/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'jcstress'
-apply plugin: "org.javamodularity.moduleplugin"
+
 
 description = "PerfMark Java9 API"
 ext.moduleName = "io.perfmark.java9"
@@ -8,6 +8,8 @@ if (!JavaVersion.current().isJava9Compatible()) {
     project.tasks.all {
         task -> task.enabled = false
     }
+} else {
+    apply plugin: "org.javamodularity.moduleplugin"
 }
 
 sourceCompatibility = 1.9

--- a/java9/build.gradle
+++ b/java9/build.gradle
@@ -14,9 +14,9 @@ sourceCompatibility = 1.9
 targetCompatibility = 1.9
 
 dependencies {
-    implementation project(':perfmark-impl')
+    implementation project(path: ':perfmark-impl', configuration: 'archives')
     compileOnly libraries.jsr305
-    testImplementation project(':perfmark-api')
+    testImplementation project(path: ':perfmark-api', configuration: 'archives')
     jcstressImplementation project(':perfmark-impl')
 }
 

--- a/java9/src/main/java/io/perfmark/java9/package-info.java
+++ b/java9/src/main/java/io/perfmark/java9/package-info.java
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * Java 9+ enabled generator and mark-holder.
+ */
 @javax.annotation.CheckReturnValue
 @javax.annotation.ParametersAreNonnullByDefault
 package io.perfmark.java9;

--- a/java9/src/main/java/io/perfmark/java9/package-info.java
+++ b/java9/src/main/java/io/perfmark/java9/package-info.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-/**
- * Java 9+ enabled generator and mark-holder.
- */
+/** Java 9+ enabled generator and mark-holder. */
 @javax.annotation.CheckReturnValue
 @javax.annotation.ParametersAreNonnullByDefault
 package io.perfmark.java9;

--- a/java9/src/main/java/module-info.java
+++ b/java9/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module io.perfmark.java9 {
+    requires io.perfmark.impl;
+
+    opens io.perfmark.java9 to io.perfmark.impl;
+}

--- a/java9/src/main/java/module-info.java
+++ b/java9/src/main/java/module-info.java
@@ -1,5 +1,22 @@
-module io.perfmark.java9 {
-    requires io.perfmark.impl;
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-    opens io.perfmark.java9 to io.perfmark.impl;
+module io.perfmark.java9 {
+  requires io.perfmark.impl;
+
+  opens io.perfmark.java9 to
+      io.perfmark.impl;
 }

--- a/traceviewer/build.gradle
+++ b/traceviewer/build.gradle
@@ -1,4 +1,5 @@
 description = "PerfMark Trace Viewer"
+ext.moduleName = "io.perfmark.traceviewer"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/tracewriter/build.gradle
+++ b/tracewriter/build.gradle
@@ -1,4 +1,5 @@
 description = "PerfMark Tracer Output"
+ext.moduleName = "io.perfmark.tracewriter"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7


### PR DESCRIPTION
This makes Perfmark compatible with thew Java 9 Module system.   For classes compiled for 8 and lower, an `Automatic-Module-Name` field is added to the `MANIFEST.MF`, to ensure a stable module name.   (and not derive it from the jar name).   For the `java9` package, an actual module descriptor is added, which I have tested locally works.  