### PR TITLE
all: update plugins to work with Gradle 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: java
 
 matrix:
   include:
-    - jdk: openjdk8
     - jdk: openjdk11
-    - jdk: openjdk15 
 
 
 notifications:

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
+        mavenCentral()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.github.erizo.gradle:jcstress-gradle-plugin:0.8.8'
+        classpath 'io.github.reyerizo.gradle:jcstress-gradle-plugin:0.8.10'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.1'
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.5.3"
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8"
@@ -42,7 +43,7 @@ subprojects {
     }
 
     checkstyle {
-        configDir = file("$rootDir/buildscripts")
+        configDirectory = file("$rootDir/buildscripts")
         toolVersion = "6.17"
         ignoreFailures = false
         if (rootProject.hasProperty("checkstyle.ignoreFailures")) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
         mavenCentral()
+        jcenter()
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ buildscript {
         classpath 'io.github.reyerizo.gradle:jcstress-gradle-plugin:0.8.10'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.1'
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.5.3"
-        classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8"
-        classpath "org.javamodularity:moduleplugin:1.7.0"
+        classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.9"
+        classpath "org.javamodularity:moduleplugin:1.8.1"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
         mavenCentral()
-        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
JC stress is still not working with it yet, but the other fixes seem okay.