### PR TITLE
Revert "build(deps): bump actions/checkout from 2 to 2.3.4"

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Reverts perfmark/perfmark#83

The `@2` already point to the latest version. This PR was cause by dependabot/dependabot-core#3194 and fixed by dependabot/dependabot-core#3708.