### PR TITLE
api: avoid logging in static init.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -31,13 +31,13 @@ dependencies {
 }
 
 compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 compileJmhJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 java {

--- a/api/src/main/java/io/perfmark/PerfMark.java
+++ b/api/src/main/java/io/perfmark/PerfMark.java
@@ -92,14 +92,10 @@ public final class PerfMark {
 
   static {
     Impl instance = null;
-    Level level = Level.WARNING;
     Throwable err = null;
     Class<?> clz = null;
     try {
       clz = Class.forName("io.perfmark.impl.SecretPerfMarkImpl$PerfMarkImpl");
-    } catch (ClassNotFoundException e) {
-      level = Level.FINE;
-      err = e;
     } catch (Throwable t) {
       err = t;
     }
@@ -116,7 +112,13 @@ public final class PerfMark {
       impl = new Impl(Impl.NO_TAG);
     }
     if (err != null) {
-      Logger.getLogger(PerfMark.class.getName()).log(level, "Error during PerfMark.<clinit>", err);
+      try {
+        if (Boolean.getBoolean("io.perfmark.debug")) {
+          Logger.getLogger(PerfMark.class.getName()).log(Level.FINE, "Error during PerfMark.<clinit>", err);
+        }
+      } catch (Throwable e) {
+        // ignored.
+      }
     }
   }
 


### PR DESCRIPTION
The logging system in Java is pretty heavy weight, causing a lot of class loading to happen, Service Loaders, and Shutdown hooks.   It is expected that PerfMark is included in a lot
of places, but only occasionally accompanied by the implementation.    Avoid logging in the cases where the impl is absent. These were already FINE level logs usually, so they would
have been invisible in the common case.

Additionally, this also tries to avoid throwing an exception in the event a security manager is present.  Both Logger init and Boolean.getBoolean have Security Manager implications.
While the Secutiy is slated to go away in a later version of Java, it is still present in the versions PerfMark targets.