### PR TITLE
Avoid logging in common case.

### DIFF
--- a/api/src/main/java/io/perfmark/PerfMark.java
+++ b/api/src/main/java/io/perfmark/PerfMark.java
@@ -113,7 +113,7 @@ public final class PerfMark {
     }
     if (err != null) {
       try {
-        if (Boolean.getBoolean("io.perfmark.debug")) {
+        if (Boolean.getBoolean("io.perfmark.PerfMark.debug")) {
           Logger.getLogger(PerfMark.class.getName()).log(Level.FINE, "Error during PerfMark.<clinit>", err);
         }
       } catch (Throwable e) {

--- a/api/src/test/java/io/perfmark/PerfMarkTest.java
+++ b/api/src/test/java/io/perfmark/PerfMarkTest.java
@@ -71,7 +71,7 @@ public class PerfMarkTest {
     logger.setFilter(filter);
     try {
       System.setProperty("io.perfmark.debug", "true");
-      runWithProperty(System.getProperties(), "io.perfmark.debug", "true", () -> {
+      runWithProperty(System.getProperties(), "io.perfmark.PerfMark.debug", "true", () -> {
         try {
           // Force Initialization.
           Class.forName(PerfMark.class.getName(), true, loader);
@@ -295,7 +295,7 @@ public class PerfMarkTest {
   private static <T> T runWithProperty(Properties properties, String name, String value, Callable<T> runnable)
       throws Exception {
     if (properties.containsKey(name)) {
-      String oldProp = null;
+      String oldProp;
       oldProp = properties.getProperty(name);
       try {
         System.setProperty(name, value);
@@ -315,16 +315,19 @@ public class PerfMarkTest {
 
   private static class TestClassLoader extends ClassLoader {
 
-    private final List<String> classesToExclude;
+    private final List<String> classesToDrop;
 
-    TestClassLoader(ClassLoader parent, String ... classesToExclude) {
+    TestClassLoader(ClassLoader parent, String ... classesToDrop) {
       super(parent);
-      this.classesToExclude = Arrays.asList(classesToExclude);
+      this.classesToDrop = Arrays.asList(classesToDrop);
     }
 
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-      if (!name.startsWith("io.perfmark.") || classesToExclude.contains(name)) {
+      if (classesToDrop.contains(name)) {
+        throw new ClassNotFoundException();
+      }
+      if (!name.startsWith("io.perfmark.")) {
         return super.loadClass(name, resolve);
       }
       try (InputStream is = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {

--- a/impl/build.gradle
+++ b/impl/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "me.champeau.jmh"
+}
+
 description = "PerfMark Implementation API"
 ext.moduleName =  "io.perfmark.impl"
 ext.jdkVersion = JavaVersion.VERSION_1_6
@@ -21,3 +25,39 @@ dependencies {
             libraries.errorprone
 }
 
+
+jmh {
+
+    timeOnIteration = "1s"
+    warmup = "1s"
+    fork = 400
+    warmupIterations = 0
+
+    includes = ["ClassInit"]
+    profilers = ["cl"]
+    jvmArgs = ["-Dio.perfmark.PerfMark.debug=true"]
+
+    /*
+    profilers = ["perfasm"]
+
+    jvmArgs = [
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+LogCompilation",
+            "-XX:LogFile=/tmp/blah.txt",
+            "-XX:+PrintAssembly",
+            "-XX:+PrintInterpreter",
+            "-XX:+PrintNMethods",
+            "-XX:+PrintNativeNMethods",
+            "-XX:+PrintSignatureHandlers",
+            "-XX:+PrintAdapterHandlers",
+            "-XX:+PrintStubCode",
+            "-XX:+PrintCompilation",
+            "-XX:+PrintInlining",
+            "-XX:+TraceClassLoading",
+            "-XX:PrintAssemblyOptions=syntax",
+            "-XX:PrintAssemblyOptions=intel"
+    ]
+     */
+
+    //duplicateClassesStrategy DuplicatesStrategy.INCLUDE
+}

--- a/impl/src/jmh/java/io/perfmark/impl/SecretPerfMarkImplClassInitBenchmark.java
+++ b/impl/src/jmh/java/io/perfmark/impl/SecretPerfMarkImplClassInitBenchmark.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.perfmark.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@Fork(1000)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+public class SecretPerfMarkImplClassInitBenchmark {
+
+  private ClassLoader loader;
+
+  @Setup
+  public void setup() {
+    loader =
+        new TestClassLoader(getClass().getClassLoader(),
+            "io.perfmark.java7.SecretMethodHandleGenerator$MethodHandleGenerator",
+            "io.perfmark.java9.SecretVarHandleGenerator$VarHandleGenerator",
+            "io.perfmark.java6.SecretVolatileGenerator$VolatileGenerator");
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SingleShotTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public Object forName_noinit() throws Exception {
+    return Class.forName(SecretPerfMarkImpl.PerfMarkImpl.class.getName(), false, loader);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SingleShotTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public Object forName_init() throws Exception {
+    return Class.forName(SecretPerfMarkImpl.PerfMarkImpl.class.getName(), true, loader);
+  }
+
+  private static class TestClassLoader extends ClassLoader {
+
+    private final List<String> classesToDrop;
+
+    TestClassLoader(ClassLoader parent, String ... classesToDrop) {
+      super(parent);
+      this.classesToDrop = Arrays.asList(classesToDrop);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+      if (classesToDrop.contains(name)) {
+        // Throw an exception, just like the real one would.
+        throw new ClassNotFoundException();
+      }
+      if (!name.startsWith("io.perfmark.")) {
+        return super.loadClass(name, resolve);
+      }
+      try (InputStream is = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {
+        if (is == null) {
+          throw new ClassNotFoundException(name);
+        }
+        byte[] data = is.readAllBytes();
+        Class<?> clz = defineClass(name, data, 0, data.length);
+        if (resolve) {
+          resolveClass(clz);
+        }
+        return clz;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
+++ b/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
@@ -18,11 +18,8 @@ package io.perfmark.impl;
 
 import io.perfmark.Impl;
 import io.perfmark.Link;
-import io.perfmark.PerfMark;
 import io.perfmark.StringFunction;
 import io.perfmark.Tag;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -94,7 +91,10 @@ final class SecretPerfMarkImpl {
           Logger localLogger = Logger.getLogger(PerfMarkImpl.class.getName());
           log = localLogger;
           for (Throwable problem : problems) {
-            localLogger.log(Level.FINE, "Error loading MarkHolderProvider", problem);
+            if (problem == null) {
+              continue;
+            }
+            localLogger.log(Level.FINE, "Error loading Generator", problem);
           }
           localLogger.log(Level.FINE, "Using {0}", new Object[] {generator.getClass().getName()});
           logEnabledChange(startEnabled, startEnabledSuccess);

--- a/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
+++ b/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
@@ -387,4 +387,6 @@ final class SecretPerfMarkImpl {
       return ((gen >>> Generator.GEN_OFFSET) & 0x1L) != 0L;
     }
   }
+
+  private SecretPerfMarkImpl() {}
 }

--- a/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
+++ b/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
@@ -39,6 +39,7 @@ final class SecretPerfMarkImpl {
 
     private static final AtomicLong linkIdAlloc = new AtomicLong(1);
     private static final Generator generator;
+
     private static final Logger logger;
 
     private static long actualGeneration;
@@ -101,7 +102,7 @@ final class SecretPerfMarkImpl {
       }
       boolean startEnabled = false;
       try {
-        startEnabled = Boolean.parseBoolean(System.getProperty(START_ENABLED_PROPERTY, "false"));
+        startEnabled = Boolean.getBoolean(START_ENABLED_PROPERTY);
       } catch (Throwable t) {
         warnings.add(t);
       }

--- a/impl/src/main/java/io/perfmark/impl/Storage.java
+++ b/impl/src/main/java/io/perfmark/impl/Storage.java
@@ -261,7 +261,5 @@ public final class Storage {
     }
   }
 
-  private Storage() {
-    throw new AssertionError("nope");
-  }
+  private Storage() {}
 }


### PR DESCRIPTION
```
//Before
Benchmark                                                               Mode  Cnt      Score     Error        Units
SecretPerfMarkImplClassInitBenchmark.forName_init                         ss  400  17209.431 ± 354.263        us/op
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.load             ss  400      3.599 ±   0.062  classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.load.norm        ss  400    152.523 ±   0.163   classes/op
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.unload           ss  400        ≈ 0            classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.unload.norm      ss  400        ≈ 0             classes/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit                       ss  400   6958.959 ± 133.175        us/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.load           ss  400      1.032 ±   0.018  classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.load.norm      ss  400     77.203 ±   0.224   classes/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.unload         ss  400        ≈ 0            classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.unload.norm    ss  400        ≈ 0             classes/op

//After, io.perfmark.PerfMark.debug false
Benchmark                                                               Mode  Cnt      Score     Error        Units
SecretPerfMarkImplClassInitBenchmark.forName_init                         ss  400  10837.033 ± 186.085        us/op
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.load             ss  400      1.407 ±   0.022  classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.load.norm        ss  400     83.015 ±   0.252   classes/op
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.unload           ss  400        ≈ 0            classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.unload.norm      ss  400        ≈ 0             classes/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit                       ss  400   6833.084 ± 100.928        us/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.load           ss  400      1.018 ±   0.016  classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.load.norm      ss  400     77.163 ±   0.230   classes/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.unload         ss  400        ≈ 0            classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.unload.norm    ss  400        ≈ 0             classes/op

//After, io.perfmark.PerfMark.debug true
Benchmark                                                               Mode  Cnt      Score     Error        Units
SecretPerfMarkImplClassInitBenchmark.forName_init                         ss  400  16939.197 ± 305.943        us/op
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.load             ss  400      3.553 ±   0.054  classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.load.norm        ss  400    152.603 ±   0.153   classes/op
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.unload           ss  400        ≈ 0            classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_init:·class.unload.norm      ss  400        ≈ 0             classes/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit                       ss  400   6975.875 ± 147.525        us/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.load           ss  400      1.034 ±   0.018  classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.load.norm      ss  400     77.313 ±   0.211   classes/op
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.unload         ss  400        ≈ 0            classes/sec
SecretPerfMarkImplClassInitBenchmark.forName_noinit:·class.unload.norm    ss  400        ≈ 0             classes/op
```