### PR TITLE
java9: record benchmarks in permutation

### DIFF
--- a/java9/build.gradle.kts
+++ b/java9/build.gradle.kts
@@ -50,12 +50,21 @@ tasks.named<JavaCompile>("compileJava") {
     targetCompatibility = jdkVersion.toString()
 }
 
+tasks.named<JavaCompile>("compileJmhJava") {
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+
 tasks.register<Test>("jmh") {
     description = "Runs integration tests."
     group = "stress"
 
     testClassesDirs = sourceSets["jmh"].output.classesDirs
     classpath = sourceSets["jmh"].runtimeClasspath
+
+    javaLauncher.set(javaToolchains.launcherFor({
+        languageVersion.set(JavaLanguageVersion.of("11"))
+    }))
 }
 
 

--- a/java9/src/jmh/java/io/perfmark/java9/VarHandleGeneratorBenchmarkTest.java
+++ b/java9/src/jmh/java/io/perfmark/java9/VarHandleGeneratorBenchmarkTest.java
@@ -17,6 +17,7 @@
 package io.perfmark.java9;
 
 import io.perfmark.impl.Generator;
+import io.perfmark.testing.GarbageCollector;
 import io.perfmark.testing.GeneratorBenchmark;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;

--- a/java9/src/jmh/java/io/perfmark/java9/VarHandleMarkHolderBenchmarkTest.java
+++ b/java9/src/jmh/java/io/perfmark/java9/VarHandleMarkHolderBenchmarkTest.java
@@ -16,11 +16,18 @@
 
 package io.perfmark.java9;
 
+import static java.util.List.of;
+
 import io.perfmark.impl.MarkHolder;
+import io.perfmark.testing.GarbageCollector;
 import io.perfmark.testing.MarkHolderBenchmark;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.runner.Runner;
@@ -28,10 +35,30 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class VarHandleMarkHolderBenchmarkTest {
+
+  @Parameterized.Parameter(0)
+  public GarbageCollector gc;
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> args() {
+    List<Object[]> cases = new ArrayList<>();
+    for (GarbageCollector gc : GarbageCollector.values()) {
+      if (gc != GarbageCollector.CMS) {
+        continue;
+      }
+      cases.add(List.of(gc).toArray(new Object[0]));
+    }
+
+    return List.copyOf(cases);
+  }
+
   @Test
   public void markHolderBenchmark() throws Exception {
+    List<String> jvmArgs = new ArrayList<>();
+    jvmArgs.add("-da");
+    jvmArgs.addAll(gc.jvmArgs());
     Options options = new OptionsBuilder()
         .include(VarHandleMarkHolderBenchmark.class.getCanonicalName())
         .measurementIterations(10)
@@ -39,9 +66,10 @@ public class VarHandleMarkHolderBenchmarkTest {
         .forks(1)
         .warmupTime(TimeValue.seconds(1))
         .measurementTime(TimeValue.seconds(1))
+        .param("GC", gc.name())
         .shouldFailOnError(true)
         // This is necessary to run in the IDE, otherwise it would inherit the VM args.
-        .jvmArgs("-da", "-XX:+UseSerialGC")
+        .jvmArgs(jvmArgs.toArray(new String[0]))
         .build();
 
     new Runner(options).run();

--- a/testing/src/main/java/io/perfmark/testing/GarbageCollector.java
+++ b/testing/src/main/java/io/perfmark/testing/GarbageCollector.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Carl Mastrangelo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.perfmark.testing;
+
+import java.util.List;
+
+public enum GarbageCollector {
+  G1("-XX:+UseG1GC"),
+  ZGC("-XX:+UseZGC"),
+  SHENANDOAH("-XX:+UseShenandoahGC"),
+  SERIAL("-XX:+UseSerialGC"),
+  PARALLEL("-XX:+UseParallelGC"),
+  EPSILON("-XX:+UnlockExperimentalVMOptions", "-XX:+UseEpsilonGC"),
+  CMS("-XX:+UseConcMarkSweepGC"),
+  ;
+
+  private final List<String> jvmArgs;
+
+  GarbageCollector(String ... jvmArgs) {
+    this.jvmArgs = List.of(jvmArgs);
+  }
+
+  public List<String> jvmArgs() {
+    return jvmArgs;
+  }
+}

--- a/testing/src/main/java/io/perfmark/testing/MarkHolderBenchmark.java
+++ b/testing/src/main/java/io/perfmark/testing/MarkHolderBenchmark.java
@@ -24,6 +24,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -66,6 +67,9 @@ public class MarkHolderBenchmark {
   public final void setUp() {
     markHolder = getMarkHolder();
   }
+
+  @Param({})
+  GarbageCollector GC;
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)


### PR DESCRIPTION
Results:

```
Benchmark                                                                               (GC)  Mode  Cnt  Score   Error  Units
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_noTag           CMS  avgt   10  3.506 ± 0.139  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_noTag       EPSILON  avgt   10  3.708 ± 0.156  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_noTag            G1  avgt   10  4.573 ± 0.241  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_noTag      PARALLEL  avgt   10  3.666 ± 0.021  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_noTag        SERIAL  avgt   10  3.724 ± 0.078  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_noTag    SHENANDOAH  avgt   10  6.089 ± 1.010  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_noTag           ZGC  avgt   10  3.811 ± 0.016  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_subname         CMS  avgt   10  4.545 ± 0.027  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_subname     EPSILON  avgt   10  4.312 ± 0.022  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_subname          G1  avgt   10  5.639 ± 0.252  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_subname    PARALLEL  avgt   10  4.776 ± 0.175  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_subname      SERIAL  avgt   10  4.869 ± 0.339  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_subname  SHENANDOAH  avgt   10  6.784 ± 0.579  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_subname         ZGC  avgt   10  4.510 ± 0.041  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_tag             CMS  avgt   10  5.824 ± 0.298  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_tag         EPSILON  avgt   10  4.840 ± 0.157  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_tag              G1  avgt   10  6.785 ± 0.053  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_tag        PARALLEL  avgt   10  6.469 ± 0.239  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_tag          SERIAL  avgt   10  6.418 ± 0.373  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_tag      SHENANDOAH  avgt   10  9.539 ± 0.782  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.event_name_tag             ZGC  avgt   10  5.723 ± 0.021  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.link                       CMS  avgt   10  2.765 ± 0.065  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.link                   EPSILON  avgt   10  3.122 ± 0.098  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.link                        G1  avgt   10  3.092 ± 0.097  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.link                  PARALLEL  avgt   10  2.923 ± 0.026  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.link                    SERIAL  avgt   10  3.079 ± 0.058  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.link                SHENANDOAH  avgt   10  4.178 ± 0.022  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.link                       ZGC  avgt   10  3.073 ± 0.035  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_noTag           CMS  avgt   10  3.447 ± 0.187  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_noTag       EPSILON  avgt   10  3.785 ± 0.123  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_noTag            G1  avgt   10  3.767 ± 0.021  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_noTag      PARALLEL  avgt   10  3.688 ± 0.025  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_noTag        SERIAL  avgt   10  3.655 ± 0.111  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_noTag    SHENANDOAH  avgt   10  5.042 ± 0.181  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_noTag           ZGC  avgt   10  3.801 ± 0.053  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_subname         CMS  avgt   10  4.513 ± 0.271  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_subname     EPSILON  avgt   10  4.141 ± 0.163  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_subname          G1  avgt   10  5.529 ± 0.361  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_subname    PARALLEL  avgt   10  4.737 ± 0.016  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_subname      SERIAL  avgt   10  4.617 ± 0.048  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_subname  SHENANDOAH  avgt   10  5.857 ± 0.216  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_subname         ZGC  avgt   10  4.562 ± 0.174  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_tag             CMS  avgt   10  6.336 ± 0.274  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_tag         EPSILON  avgt   10  4.948 ± 0.059  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_tag              G1  avgt   10  6.628 ± 0.562  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_tag        PARALLEL  avgt   10  6.465 ± 0.554  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_tag          SERIAL  avgt   10  6.143 ± 0.118  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_tag      SHENANDOAH  avgt   10  9.237 ± 0.385  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.start_name_tag             ZGC  avgt   10  6.288 ± 0.042  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_noTag            CMS  avgt   10  4.247 ± 1.205  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_noTag        EPSILON  avgt   10  3.772 ± 0.231  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_noTag             G1  avgt   10  4.193 ± 0.055  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_noTag       PARALLEL  avgt   10  3.911 ± 0.285  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_noTag         SERIAL  avgt   10  3.520 ± 0.049  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_noTag     SHENANDOAH  avgt   10  5.143 ± 0.021  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_noTag            ZGC  avgt   10  3.741 ± 0.132  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_subname          CMS  avgt   10  4.494 ± 0.057  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_subname      EPSILON  avgt   10  4.258 ± 0.083  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_subname           G1  avgt   10  5.695 ± 0.061  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_subname     PARALLEL  avgt   10  4.948 ± 0.255  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_subname       SERIAL  avgt   10  5.066 ± 0.241  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_subname   SHENANDOAH  avgt   10  7.169 ± 0.042  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_subname          ZGC  avgt   10  4.810 ± 0.074  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_tag              CMS  avgt   10  6.448 ± 0.294  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_tag          EPSILON  avgt   10  4.720 ± 0.048  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_tag               G1  avgt   10  7.046 ± 0.119  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_tag         PARALLEL  avgt   10  6.216 ± 0.054  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_tag           SERIAL  avgt   10  5.923 ± 0.041  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_tag       SHENANDOAH  avgt   10  9.237 ± 0.116  ns/op
VarHandleMarkHolderBenchmarkTest.VarHandleMarkHolderBenchmark.stop_name_tag              ZGC  avgt   10  5.748 ± 0.288  ns/op

```