### PR TITLE
api: remove jsr305

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -28,7 +28,6 @@ tasks.named<JavaCompile>("compileJava") {
 }
 
 dependencies {
-    compileOnly(libs.jsr305)
     compileOnly(libs.errorprone)
 
     testImplementation(project(":perfmark-impl"))

--- a/api/src/main/java/io/perfmark/Impl.java
+++ b/api/src/main/java/io/perfmark/Impl.java
@@ -16,8 +16,6 @@
 
 package io.perfmark;
 
-import javax.annotation.Nullable;
-
 public class Impl {
   static final String NO_TAG_NAME = "";
   static final long NO_TAG_ID = Long.MIN_VALUE;
@@ -82,11 +80,10 @@ public class Impl {
   protected <T> void attachTag(
       String tagName, T tagObject, StringFunction<? super T> stringFunction) {}
 
-  protected Tag createTag(@Nullable String tagName, long tagId) {
+  protected Tag createTag(String tagName, long tagId) {
     return NO_TAG;
   }
 
-  @Nullable
   protected static String unpackTagName(Tag tag) {
     return tag.tagName;
   }
@@ -99,7 +96,7 @@ public class Impl {
     return link.linkId;
   }
 
-  protected static Tag packTag(@Nullable String tagName, long tagId) {
+  protected static Tag packTag(String tagName, long tagId) {
     return new Tag(tagName, tagId);
   }
 

--- a/api/src/main/java/io/perfmark/Tag.java
+++ b/api/src/main/java/io/perfmark/Tag.java
@@ -16,14 +16,12 @@
 
 package io.perfmark;
 
-import javax.annotation.Nullable;
-
 /** Tag is a dynamic, runtime created identifier (such as an RPC id). */
 public final class Tag {
-  @Nullable final String tagName;
+  final String tagName;
   final long tagId;
 
-  Tag(@Nullable String tagName, long tagId) {
+  Tag(String tagName, long tagId) {
     // tagName should be non-null, but checking is expensive
     this.tagName = tagName;
     this.tagId = tagId;

--- a/api/src/main/java/io/perfmark/TaskCloseable.java
+++ b/api/src/main/java/io/perfmark/TaskCloseable.java
@@ -25,7 +25,6 @@ import java.io.Closeable;
  * <p>Implementation note: This would normally implement {@code AutoCloseable}, but that is not
  * available in Java 6. A future version of PerfMark may implement the parent interface instead.
  *
- *
  * @since 0.23.0
  */
 public final class TaskCloseable implements Closeable {

--- a/api/src/main/java/io/perfmark/package-info.java
+++ b/api/src/main/java/io/perfmark/package-info.java
@@ -14,6 +14,5 @@
  * limitations under the License.
  */
 
-@javax.annotation.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@com.google.errorprone.annotations.CheckReturnValue
 package io.perfmark;


### PR DESCRIPTION
This removes javax.* types, which weren't ever really enforced. Primarily, Nullable was added, but the api surface is careful to not fail when null is provided, so it's not really needed.