### PR TITLE
all: revert Sealed in Manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
     afterEvaluate {
         jar {
             manifest {
-                attributes  ("Automatic-Module-Name": moduleName,
+                attributes ("Automatic-Module-Name": moduleName,
                     "Implementation-Version": archiveVersion.get(),
                     "Implementation-Title": "PerfMark (https://www.perfmark.io/)",
                     "Implementation-Vendor":
@@ -52,10 +52,8 @@ subprojects {
                     "Specification-Version": archiveVersion.get(),
                     "Specification-Title": "PerfMark (https://www.perfmark.io/)",
                     "Specification-Vendor": "Carl Mastrangelo (https://www.perfmark.io/)",
-                    "Sealed": "true",
                     "Carl-Is-Awesome": "true")
             }
-
         }
     }
 


### PR DESCRIPTION
This doesn't seem to provide as much benefit, but it does make loading more difficult if multiple copies are accidentally on the class path. Discovered while benchmarking.