### PR TITLE
impl: remove asserts causing classload

### DIFF
--- a/api/testing/src/test/java/io/perfmark/apitesting/ArtifactTest.java
+++ b/api/testing/src/test/java/io/perfmark/apitesting/ArtifactTest.java
@@ -50,7 +50,7 @@ public class ArtifactTest {
   private static void checkPackage(Package pkg) {
     Truth.assertWithMessage(pkg.toString()).that(pkg.getImplementationTitle()).contains("PerfMark");
     Truth.assertWithMessage(pkg.toString()).that(pkg.toString()).contains("PerfMark");
-    Truth.assertWithMessage(pkg.toString()).that(pkg.isSealed()).isTrue();
+    Truth.assertWithMessage(pkg.toString()).that(pkg.isSealed()).isFalse();
 
     String vers = pkg.getImplementationVersion();
     assertNotNull(vers);

--- a/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
+++ b/impl/src/main/java/io/perfmark/impl/SecretPerfMarkImpl.java
@@ -51,7 +51,9 @@ final class SecretPerfMarkImpl {
     private static long actualGeneration;
 
     static {
-      assert ENABLED_BIT_SPACE + Generator.GEN_OFFSET + GEN_TIMESTAMP_SPACE <= 64;
+      // Avoid using asserts here, because it triggers a class load of the outer SecretPerfMarkImpl.
+      // See https://docs.oracle.com/javase/specs/jls/se7/html/jls-14.html#jls-14.10
+      // assert ENABLED_BIT_SPACE + Generator.GEN_OFFSET + GEN_TIMESTAMP_SPACE <= 64;
       Generator gen = null;
       Throwable[] problems = new Throwable[4];
       // Avoid using a for-loop for this code, as it makes it easier for tools like Proguard to rewrite.
@@ -159,7 +161,7 @@ final class SecretPerfMarkImpl {
 
     // VisibleForTesting
     static long nextGeneration(final long currentGeneration, final long nanosSinceInit) {
-      assert currentGeneration != Generator.FAILURE;
+      // currentGeneration != Generator.FAILURE;
       long currentMibros = mibrosFromGeneration(currentGeneration);
       long mibrosSinceInit = Math.min(mibrosFromNanos(nanosSinceInit), MAX_MIBROS); // 54bits
       boolean nextEnabled = !isEnabled(currentGeneration);
@@ -174,7 +176,7 @@ final class SecretPerfMarkImpl {
       }
       long enabledMask = nextEnabled ? INCREMENT : 0;
       long mibroMask = (nextMibros << (Generator.GEN_OFFSET + ENABLED_BIT_SPACE));
-      assert (enabledMask & mibroMask) == 0;
+      // (enabledMask & mibroMask) == 0;
       return mibroMask | enabledMask;
     }
 


### PR DESCRIPTION
```
BEFORE:

Benchmark                                             Mode  Cnt     Score     Error        Units
ClassInitBenchmark.forName_init                         ss  400  8411.036 ± 148.305        us/op
ClassInitBenchmark.forName_init:·class.load             ss  400     1.136 ±   0.016  classes/sec
ClassInitBenchmark.forName_init:·class.load.norm        ss  400    71.040 ±   0.113   classes/op
ClassInitBenchmark.forName_init:·class.unload           ss  400       ≈ 0            classes/sec
ClassInitBenchmark.forName_init:·class.unload.norm      ss  400       ≈ 0             classes/op
ClassInitBenchmark.forName_noinit                       ss  400  3077.689 ±  52.719        us/op
ClassInitBenchmark.forName_noinit:·class.load           ss  400     0.612 ±   0.007  classes/sec
ClassInitBenchmark.forName_noinit:·class.load.norm      ss  400    57.815 ±   0.093   classes/op
ClassInitBenchmark.forName_noinit:·class.unload         ss  400       ≈ 0            classes/sec
ClassInitBenchmark.forName_noinit:·class.unload.norm    ss  400       ≈ 0             classes/op

AFTER

Benchmark                                             Mode  Cnt     Score     Error        Units
ClassInitBenchmark.forName_init                         ss  400  7975.843 ± 114.276        us/op
ClassInitBenchmark.forName_init:·class.load             ss  400     1.080 ±   0.013  classes/sec
ClassInitBenchmark.forName_init:·class.load.norm        ss  400    69.763 ±   0.116   classes/op
ClassInitBenchmark.forName_init:·class.unload           ss  400       ≈ 0            classes/sec
ClassInitBenchmark.forName_init:·class.unload.norm      ss  400       ≈ 0             classes/op
ClassInitBenchmark.forName_noinit                       ss  400  3103.897 ±  60.140        us/op
ClassInitBenchmark.forName_noinit:·class.load           ss  400     0.618 ±   0.009  classes/sec
ClassInitBenchmark.forName_noinit:·class.load.norm      ss  400    57.853 ±   0.086   classes/op
ClassInitBenchmark.forName_noinit:·class.unload         ss  400       ≈ 0            classes/sec
ClassInitBenchmark.forName_noinit:·class.unload.norm    ss  400       ≈ 0             classes/op

```