### PR TITLE
Add Android support

### DIFF
--- a/tracewriter/src/main/java/io/perfmark/tracewriter/TraceEventWriter.java
+++ b/tracewriter/src/main/java/io/perfmark/tracewriter/TraceEventWriter.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -295,11 +294,23 @@ public final class TraceEventWriter {
         errors.add(e);
       }
       try {
-        String name = ManagementFactory.getRuntimeMXBean().getName();
+        Class<?> clz = Class.forName("java.lang.management.ManagementFactory");
+        Method currentMethod = clz.getMethod("getRuntimeMXBean");
+        Object runtimeMXBeanObject = currentMethod.invoke(null);
+        Class<?> runtimeMXBeanClass = runtimeMXBeanObject.getClass();
+        Method pidMethod = runtimeMXBeanClass.getMethod("getName");
+        String name = (String) pidMethod.invoke(runtimeMXBeanObject);
         int index = name.indexOf('@');
         if (index != -1) {
           return Long.parseLong(name.substring(0, index));
         }
+      } catch (Exception | Error e) {
+        errors.add(e);
+      }
+      try {
+        Class<?> clz = Class.forName("android.os.Process");
+        Method pidMethod = clz.getMethod("myPid");
+        return ((Integer) pidMethod.invoke(null)).longValue();
       } catch (Exception | Error e) {
         errors.add(e);
       }


### PR DESCRIPTION
Use Android API to fetch the PID if found.

Use reflection to invoke `RuntimeMXBean::getName` since Android has not implemented this.